### PR TITLE
@cryptohog/predicate fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,24 +1,28 @@
-# TX-FLOW-ENGINE Development Guidelines
+# STATE-TRANSITION-SDK Development Guidelines
 
 ## Build Commands
-- Build project: `npm run build` (creates browser and Node.js bundles in docs/ directory)
-- Production build: Modify webpack.config.js mode to 'production' before running build
+- Build project: `npm run build` (creates TypeScript output in lib directory)
+- Type checking: `npm run build:check` 
+- Lint code: `npm run lint` (fix automatically with `npm run lint:fix`)
+- Run all tests: `npm run test`
+- Run single test: `npx jest tests/path/to/TestFile.ts`
 - Manual testing: Use CLI tools in `cli/` directory (e.g., `./cli/mint.sh`, `./cli/send.sh`)
 
 ## Code Style Guidelines
-- **Modules**: Use CommonJS pattern with explicit `require`/`module.exports`
-- **Naming**: camelCase for variables/functions, PascalCase for classes, UPPER_SNAKE for constants
-- **Functions**: Async operations should use async/await pattern consistently
-- **Imports**: Group imports by source (internal vs external libraries)
-- **Error Handling**: Use try/catch blocks with specific error messages
-- **Parameters**: Use object destructuring for function parameters with multiple arguments
+- **Modules**: ES modules with .js extensions in imports (e.g., `import { X } from './Y.js'`)
+- **Typing**: TypeScript with strict typing; interfaces prefixed with 'I' (e.g., `ISerializable`)
+- **Naming**: camelCase for variables/methods, PascalCase for classes, UPPER_CASE for static constants
+- **Imports**: Organized by groups (builtin → external → internal) with newlines between groups
+- **Interfaces**: Define contracts (like `ISerializable` with `toCBOR()` and `toJSON()` methods)
+- **Error Handling**: Use async/await with try/catch; include specific error messages
+- **Code Organization**: Follows domain-driven design with folders by feature (token, address, etc.)
 
 ## Project Structure
-- Core engine: state_machine.js (entry point), token.js, transaction.js, state.js
-- CLI interface: Scripts in `cli/` directory for common operations
-- Web interface: Components in `src/` with HTML entry point at `src/ipts.html`
+- TypeScript source: `src/` directory with domain-specific subfolders
+- Entry point: `src/index.ts` exporting public API
+- Tests: Located in `tests/` directory with *Test.ts naming pattern
+- CLI tools: Scripts in `cli/` directory for common operations
 - Documentation: Protocol spec in `unicity-token-protocol-spec.md`
 
 ## External Dependencies
-- Main dependency: `@unicitylabs/shared` for crypto operations and transport
-- Requires Node.js crypto modules (polyfilled for browser environments)
+- Main dependency: `@unicitylabs/commons` for shared functionality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/state-transition-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Generic State Transition Flow engine for value-carrier agents",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/state-transition-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Generic State Transition Flow engine for value-carrier agents",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unicitylabs/state-transition-sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Generic State Transition Flow engine for value-carrier agents",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/predicate/BurnPredicate.ts
+++ b/src/predicate/BurnPredicate.ts
@@ -1,6 +1,7 @@
 import { DataHash } from '@unicitylabs/commons/lib/hash/DataHash.js';
 import { DataHasher } from '@unicitylabs/commons/lib/hash/DataHasher.js';
 import { HashAlgorithm } from '@unicitylabs/commons/lib/hash/HashAlgorithm.js';
+import { HexConverter } from '@unicitylabs/commons/lib/util/HexConverter.js';
 import { dedent } from '@unicitylabs/commons/lib/util/StringUtils.js';
 
 import { IPredicate } from './IPredicate.js';
@@ -8,8 +9,9 @@ import { PredicateType } from './PredicateType.js';
 import { TokenId } from '../token/TokenId.js';
 import { TokenType } from '../token/TokenType.js';
 
-interface IPredicateDto {
+interface IBurnPredicateDto {
   readonly type: PredicateType;
+  readonly msg: string;
 }
 
 const textEncoder = new TextEncoder();
@@ -19,32 +21,65 @@ export class BurnPredicate implements IPredicate {
 
   public readonly type: PredicateType = BurnPredicate.TYPE;
   public readonly hash: DataHash;
+  public readonly msg: Uint8Array;
 
-  private constructor(public readonly reference: DataHash) {
-    this.hash = reference;
+  private constructor(
+    public readonly reference: DataHash,
+    hash: DataHash,
+    msg: Uint8Array,
+  ) {
+    this.hash = hash;
+    this.msg = new Uint8Array(msg);
   }
 
-  public static async create(tokenId: TokenId, tokenType: TokenType): Promise<BurnPredicate> {
-    const reference = await BurnPredicate.calculateReference(tokenId, tokenType);
-    return new BurnPredicate(reference);
+  public static async create(
+    tokenId: TokenId,
+    tokenType: TokenType,
+    msg: Uint8Array = new Uint8Array(),
+  ): Promise<BurnPredicate> {
+    const reference = await BurnPredicate.calculateReference(tokenType, msg);
+    const hash = await BurnPredicate.calculateHash(reference, tokenId);
+
+    return new BurnPredicate(reference, hash, msg);
   }
 
-  public static async fromDto(tokenId: TokenId, tokenType: TokenType): Promise<BurnPredicate> {
-    const reference = await BurnPredicate.calculateReference(tokenId, tokenType);
+  public static async fromDto(tokenId: TokenId, tokenType: TokenType, data: unknown): Promise<BurnPredicate> {
+    if (!BurnPredicate.isDto(data)) {
+      throw new Error('Invalid burn predicate dto');
+    }
 
-    return new BurnPredicate(reference);
+    const msg = data.msg ? HexConverter.decode(data.msg) : new Uint8Array();
+    const reference = await BurnPredicate.calculateReference(tokenType, msg);
+    const hash = await BurnPredicate.calculateHash(reference, tokenId);
+
+    return new BurnPredicate(reference, hash, msg);
   }
 
-  private static calculateReference(tokenId: TokenId, tokenType: TokenType): Promise<DataHash> {
+  private static isDto(data: unknown): data is IBurnPredicateDto {
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'type' in data &&
+      data.type === PredicateType.BURN &&
+      (!('msg' in data) || typeof data.msg === 'string')
+    );
+  }
+
+  private static calculateReference(tokenType: TokenType, msg: Uint8Array): Promise<DataHash> {
     return new DataHasher(HashAlgorithm.SHA256)
       .update(textEncoder.encode(BurnPredicate.TYPE))
-      .update(tokenId.encode())
       .update(tokenType.encode())
+      .update(msg)
       .digest();
   }
 
-  public toDto(): IPredicateDto {
+  private static calculateHash(reference: DataHash, tokenId: TokenId): Promise<DataHash> {
+    return new DataHasher(HashAlgorithm.SHA256).update(reference.imprint).update(tokenId.encode()).digest();
+  }
+
+  public toDto(): IBurnPredicateDto {
     return {
+      msg: this.msg.length > 0 ? HexConverter.encode(this.msg) : '',
       type: this.type,
     };
   }
@@ -56,6 +91,8 @@ export class BurnPredicate implements IPredicate {
   public toString(): string {
     return dedent`
           Predicate[${this.type}]:
+            Message: ${this.msg.length > 0 ? HexConverter.encode(this.msg) : '<empty>'}
+            Reference: ${this.reference.toString()}
             Hash: ${this.hash.toString()}`;
   }
 

--- a/src/predicate/BurnPredicate.ts
+++ b/src/predicate/BurnPredicate.ts
@@ -65,7 +65,7 @@ export class BurnPredicate implements IPredicate {
     );
   }
 
-  private static calculateReference(tokenType: TokenType, msg: Uint8Array): Promise<DataHash> {
+  public static calculateReference(tokenType: TokenType, msg: Uint8Array): Promise<DataHash> {
     return new DataHasher(HashAlgorithm.SHA256)
       .update(textEncoder.encode(BurnPredicate.TYPE))
       .update(tokenType.encode())

--- a/src/predicate/MaskedPredicate.ts
+++ b/src/predicate/MaskedPredicate.ts
@@ -67,7 +67,7 @@ export class MaskedPredicate extends DefaultPredicate {
     return new MaskedPredicate(publicKey, data.algorithm, data.hashAlgorithm, nonce, reference, hash);
   }
 
-  private static async calculateReference(
+  public static async calculateReference(
     algorithm: string,
     publicKey: Uint8Array,
     hashAlgorithm: HashAlgorithm,

--- a/src/predicate/PredicateFactory.ts
+++ b/src/predicate/PredicateFactory.ts
@@ -11,7 +11,7 @@ export class PredicateFactory implements IPredicateFactory {
   public create(tokenId: TokenId, tokenType: TokenType, data: IPredicateDto): Promise<IPredicate> {
     switch (data.type) {
       case PredicateType.BURN:
-        return BurnPredicate.fromDto(tokenId, tokenType);
+        return BurnPredicate.fromDto(tokenId, tokenType, data);
       case PredicateType.MASKED:
         return MaskedPredicate.fromDto(tokenId, tokenType, data);
       case PredicateType.UNMASKED:

--- a/src/predicate/UnmaskedPredicate.ts
+++ b/src/predicate/UnmaskedPredicate.ts
@@ -76,7 +76,7 @@ export class UnmaskedPredicate extends DefaultPredicate {
     return new UnmaskedPredicate(publicKey, data.algorithm, data.hashAlgorithm, nonce, reference, hash);
   }
 
-  private static async calculateReference(
+  public static async calculateReference(
     algorithm: string,
     publicKey: Uint8Array,
     hashAlgorithm: HashAlgorithm,

--- a/tests/token/TokenUsageExampleTest.ts
+++ b/tests/token/TokenUsageExampleTest.ts
@@ -176,44 +176,74 @@ describe('Transition', function () {
     console.log(JSON.stringify(updateToken.toDto()));
   }, 15000);
 
-  it('should import token and be able to send it', async () => {
+  it('should create a token and send it using the new masked predicate reference calculation', async () => {
     const client = new StateTransitionClient(new TestAggregatorClient(new SparseMerkleTree(HashAlgorithm.SHA256)));
-    const secret = new TextEncoder().encode('tere');
-
-    let token = await new TokenFactory(new PredicateFactory()).create(
-      JSON.parse(
-        '{"coins":"8282784065666538393365313563643239613565626236383363383133333232376531643162383465396435356438613465376463373566396437363265646539333761184a827840376665366664326661373437373736363037336630613735363934313833646533356336333232396362613736363632366135616265393938333239366663351849","data":"55a2039369747e513ec52fc785e4332466e99d7895e8b93ef60b2b7a6c5ebb60","id":"8f051698bc608b4212799af8d4101e4ecdc3c4a79875e26e0f8a96314b742fc0","nametagTokens":[],"state":{"data":"6d7920637573746f6d2064617461","unlockPredicate":{"algorithm":"secp256k1","hashAlgorithm":0,"nonce":"06fd8259729b5ceff83a243cc7004cbb9c7299aac7903109efc3b320df7ea46a","publicKey":"024fd11e5a1601aa0e3b44e3c38378789b4889d3b0edeaa108f5374bbea97c1880","type":"MASKED"}},"transactions":[{"data":{"dataHash":"0000cd798106e367051de52c58c2570654c08457db5ea88372d88c0667ec5ba1ee2b","reason":null,"recipient":"DIRECT://0000e06706e005ae77af03e68337498180d426fd10a0962903bf30778695019cc268a039fa80","salt":"581147be23e6db30675b34e32e8b9f83c42f3dd9438857795a7793d236019ebd"},"inclusionProof":{"authenticator":{"algorithm":"secp256k1","publicKey":"034734c06faabf0fd4678a2385507647f1c5de059c459dfeaf12bad1e4e7777f88","signature":"b719243cd1c20c21a738a06ddf337f38b1ac8b1dbf5686abd8039e75de91d7cc4c127a794067dfc3c8e332fa849ce095056aad25bc6e751b653e32974e0299af01","stateHash":"0000b907450f3aea55a489f89e591191e23be1fa0a3fc8c38593d530bc528449384f"},"merkleTreePath":{"root":"00007c7bd5749a48c5196815ade3bb5b4ba2ad4e552fd1e9f316c08a4b7bbe3df11d","steps":[{"path":"7588583787075137615614200187279234761188054928514090795834318452222291284236768822","value":"0000d8b9d10a3e1b6794fa8731f931105cea60c9b02b944ac260d39eb8703d51d9a1"}]},"transactionHash":"0000ea0d167db407b34e4a0a7f3ef19e84efa62c86a100556783658a4ce7a368ff28"}},{"data":{"dataHash":"0000371dd350eb385a9eb4ccf52c532b9f2fb5b24834ea634f4c27739b604cb08102","message":"6d79206d657373616765","nameTags":[],"recipient":"DIRECT://00005000623ab227763ee71c0e2cee4793b4ed103d07a62b7d3f0b2e40177a1536a34f65756a","salt":"bfdff35cb7cf6bb9e9048e1f39fa07cd6d0fa18af0250dca9119705bda8cf87b","sourceState":{"data":"b6eba5e1ffca19abc1167bf44989d0e007a178bb822f4ee62a617aed29023fac","unlockPredicate":{"algorithm":"secp256k1","hashAlgorithm":0,"nonce":"899567b1fc3b8db30032a1c0a7121ed05fa3e0321c6f5d4371f1cb2b4541e3c0","publicKey":"031a038b3b256cee466ce9a761f04522384aa1d5becb67e0dc2ede717a1e05e0d2","type":"MASKED"}}},"inclusionProof":{"authenticator":{"algorithm":"secp256k1","publicKey":"031a038b3b256cee466ce9a761f04522384aa1d5becb67e0dc2ede717a1e05e0d2","signature":"bfa35d1e5389af7f5fec1b2199582de1a32ad04f8332f3375768092e2bdd895b009bf21748f02dda28b670ee427aaa98f71335c631b5d6afff6b5d3750190cc701","stateHash":"0000721c65078cf73f750004db64b8ac5041d2b5cc221e2c853ce082b3faf4d26638"},"merkleTreePath":{"root":"0000475f90b5296710ec788a8a333f7ac5df9cc7d0965c5b4145c520de3d738a3935","steps":[{"path":"7588569218088438164672559934214159214370139797979814927050276356134513515792040107","sibling":"00002dcec6f7ea94cfe638a188fb92959bb6bf3128507e0eab7412b75186ee27d7b6","value":"00006836b376aa8b668eed4149afb4819c1536080559ab0bf713502e9b8a8a49c893"}]},"transactionHash":"00004a01e29ed90ca54a65c36c5ed1c125d88090c2b2e31fca26647569583182601b"}}],"type":"477e128b5cc280f5f8b957260678cb7d457396ff55e4e6c823d22a70c5e4ea37","version":"2.0"}',
-      ),
-      TestTokenData.decode,
+    
+    // First, create a token from scratch with our modified MaskedPredicate implementation
+    const mintTokenData = await createMintTokenData(textEncoder.encode('token-secret'));
+    
+    // Mint a new token
+    const mintCommitment = await client.submitMintTransaction(
+      await DirectAddress.create(mintTokenData.predicate.reference.imprint),
+      mintTokenData.tokenId,
+      mintTokenData.tokenType,
+      mintTokenData.tokenData,
+      mintTokenData.coinData,
+      mintTokenData.salt,
+      await new DataHasher(HashAlgorithm.SHA256).update(mintTokenData.data).digest(),
+      null,
     );
 
+    const mintTransaction = await client.createTransaction(
+      mintCommitment,
+      await waitInclusionProof(client, mintCommitment),
+    );
+
+    // Create the initial token
+    let token = new Token(
+      mintTokenData.tokenId,
+      mintTokenData.tokenType,
+      mintTokenData.tokenData,
+      mintTokenData.coinData,
+      await TokenState.create(mintTokenData.predicate, mintTokenData.data),
+      [mintTransaction],
+    );
+    
+    // Create a recipient predicate using UnmaskedPredicate
     const salt = crypto.getRandomValues(new Uint8Array(32));
     const recipientPredicate = await UnmaskedPredicate.create(
       token.id,
       token.type,
-      await SigningService.createFromSecret(textEncoder.encode('nextuser')),
+      await SigningService.createFromSecret(textEncoder.encode('recipient-secret')),
       HashAlgorithm.SHA256,
       salt,
     );
+    
+    // Create a direct address for the recipient using the reference
     const recipient = await DirectAddress.create(recipientPredicate.reference.imprint);
 
+    // Create transaction data
     const transactionData = await TransactionData.create(
       token.state,
       recipient.toDto(),
       crypto.getRandomValues(new Uint8Array(32)),
       await new DataHasher(HashAlgorithm.SHA256).update(textEncoder.encode('new custom data')).digest(),
-      textEncoder.encode('sending via public address'),
+      textEncoder.encode('sending via address derived from reference'),
       token.nametagTokens,
     );
 
-    const tokenPredicate = token.state.unlockPredicate as MaskedPredicate;
+    // Submit the transaction
     const commitment = await client.submitTransaction(
       transactionData,
-      await SigningService.createFromSecret(secret, tokenPredicate.nonce),
+      await SigningService.createFromSecret(textEncoder.encode('token-secret'), mintTokenData.nonce),
     );
 
-    const transaction = await client.createTransaction(commitment, await client.getInclusionProof(commitment));
+    const transaction = await client.createTransaction(
+      commitment, 
+      await waitInclusionProof(client, commitment),
+    );
 
+    // Finish the transaction
     token = await client.finishTransaction(
       token,
       await TokenState.create(recipientPredicate, textEncoder.encode('new custom data')),


### PR DESCRIPTION
Separated predicate reference and hash calculation. Reference is main ingredient for address calculation, does not depend on tokenId. Hash is used primarily for the transaction request commitment for the Unicity prover service. Added message field to burn predicate.