### PR TITLE
Add browser-compatible hasher factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ const transaction = await client.createTransaction(commitment, inclusionProof);
 await client.finishTransaction(/* transaction parameters */);
 ```
 
+### Browser Usage
+
+When used in a browser environment, hashing automatically falls back to the Web
+Crypto API. Use `createDefaultDataHasherFactory()` when constructing prefix hash
+trees:
+
+```typescript
+import { createDefaultDataHasherFactory } from '@unicitylabs/state-transition-sdk';
+
+const hasherFactory = createDefaultDataHasherFactory();
+```
+
 ## Core Components
 
 ### StateTransitionClient

--- a/src/StateTransitionClient.ts
+++ b/src/StateTransitionClient.ts
@@ -21,7 +21,8 @@ import { MintTransactionData } from './transaction/MintTransactionData.js';
 import { Transaction } from './transaction/Transaction.js';
 import { TransactionData } from './transaction/TransactionData.js';
 import { DataHasherFactory } from '@unicitylabs/commons/lib/hash/DataHasherFactory.js';
-import { NodeDataHasher } from '@unicitylabs/commons/lib/hash/NodeDataHasher.js';
+import type { IDataHasher } from '@unicitylabs/commons/lib/hash/IDataHasher.js';
+import { createDefaultDataHasherFactory } from './hash/createDefaultDataHasherFactory.js';
 import { BigintConverter } from '@unicitylabs/commons/lib/util/BigintConverter.js';
 import { BurnPredicate, BurnReason } from './predicate/BurnPredicate.js';
 import { Leaf, SumLeaf, SMT, SumTree, Path, SumPath, IPathJson, ISumPathJson } from '@unicitylabs/prefix-hash-tree';
@@ -153,7 +154,7 @@ export class StateTransitionClient {
 
   // TODO: Currently we are supporting only the masked predicates.
   public async submitBurnTransactionForSplit<TD extends ISerializable, MTD extends MintTransactionData<ISerializable | null>>
-      (token: Token<TD, MTD>, coinsPerNewTokens: TokenCoinData[], sumTreeHasherFactory: DataHasherFactory<NodeDataHasher>, 
+      (token: Token<TD, MTD>, coinsPerNewTokens: TokenCoinData[], sumTreeHasherFactory: DataHasherFactory<IDataHasher>,
         sumTreeHashAlgorithm: HashAlgorithm, secret: Uint8Array<ArrayBufferLike>, 
         previousTransactionNonce: Uint8Array, dataHash: DataHash, message: Uint8Array): Promise<SubmitBurnResult>
   {

--- a/src/hash/createDefaultDataHasherFactory.ts
+++ b/src/hash/createDefaultDataHasherFactory.ts
@@ -1,0 +1,16 @@
+import { DataHasherFactory } from '@unicitylabs/commons/lib/hash/DataHasherFactory.js';
+import { NodeDataHasher } from '@unicitylabs/commons/lib/hash/NodeDataHasher.js';
+import { SubtleCryptoDataHasher } from '@unicitylabs/commons/lib/hash/SubtleCryptoDataHasher.js';
+import type { IDataHasher } from '@unicitylabs/commons/lib/hash/IDataHasher.js';
+
+/**
+ * Create a DataHasherFactory that selects the appropriate implementation
+ * depending on the environment. Browsers will use the Web Crypto based
+ * {@link SubtleCryptoDataHasher} while Node.js will fall back to
+ * {@link NodeDataHasher}.
+ */
+export function createDefaultDataHasherFactory(): DataHasherFactory<IDataHasher> {
+  const isBrowser = typeof window !== 'undefined' && typeof window.crypto !== 'undefined';
+  const Hasher = isBrowser ? SubtleCryptoDataHasher : NodeDataHasher;
+  return new DataHasherFactory(Hasher as any);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,3 +40,4 @@ export * from './transaction/TransactionData.js';
 // Core exports
 export * from './ISerializable.js';
 export * from './StateTransitionClient.js';
+export * from './hash/createDefaultDataHasherFactory.js';

--- a/src/token/TokenFactory.ts
+++ b/src/token/TokenFactory.ts
@@ -19,7 +19,8 @@ import { CborEncoder } from '@unicitylabs/commons/lib/cbor/CborEncoder.js';
 import { Path, SumPath, IPathJson, ISumPathJson, HashOptions } from '@unicitylabs/prefix-hash-tree';
 import { DataHasherFactory } from '@unicitylabs/commons/lib/hash/DataHasherFactory.js';
 import { HashAlgorithm } from '@unicitylabs/commons/lib/hash/HashAlgorithm.js';
-import { NodeDataHasher } from '@unicitylabs/commons/lib/hash/NodeDataHasher.js';
+import type { IDataHasher } from '@unicitylabs/commons/lib/hash/IDataHasher.js';
+import { createDefaultDataHasherFactory } from '../hash/createDefaultDataHasherFactory.js';
 import { dedent } from '@unicitylabs/commons/lib/util/StringUtils.js';
 import { BigintConverter } from '@unicitylabs/commons/lib/util/BigintConverter.js';
 import { BurnPredicate } from '../predicate/BurnPredicate.js';
@@ -30,8 +31,8 @@ export enum MintReasonType {
 }
 
 const hashOptions: HashOptions = {
-  dataHasherFactory: new DataHasherFactory(NodeDataHasher),
-  algorithm: HashAlgorithm.SHA256
+  dataHasherFactory: createDefaultDataHasherFactory(),
+  algorithm: HashAlgorithm.SHA256,
 };
 
 /**


### PR DESCRIPTION
## Summary
- add `createDefaultDataHasherFactory` helper to choose Node or WebCrypto
- use the new hasher factory in `TokenFactory`
- allow `submitBurnTransactionForSplit` to accept any hasher
- export the helper and document browser usage

## Testing
- `npm run build:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68429105731083329552bf2bc11497e3