### PR TITLE
Additional split test after token transfer

### DIFF
--- a/tests/e2e/token/TokenUsageExampleTest.ts
+++ b/tests/e2e/token/TokenUsageExampleTest.ts
@@ -1,6 +1,6 @@
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { StateTransitionClient } from '../../../src/StateTransitionClient.js';
-import { testTransferFlow, testSplitFlow } from '../../token/CommonTestFlow.js';
+import { testTransferFlow, testSplitFlow, testSplitFlowAfterTransfer } from '../../token/CommonTestFlow.js';
 
 describe('Transition', function () {
   it('should verify the token latest state', async () => {
@@ -22,4 +22,15 @@ describe('Transition', function () {
     const client = new StateTransitionClient(new AggregatorClient(aggregatorUrl));
     await testSplitFlow(client);
   }, 15000);
+
+  it('should split tokens after transfer', async () => {
+    const aggregatorUrl = process.env.AGGREGATOR_URL;
+    if (!aggregatorUrl) {
+      console.warn('Skipping test: AGGREGATOR_URL environment variable is not set');
+      return;
+    }
+    const client = new StateTransitionClient(new AggregatorClient(aggregatorUrl));
+    await testSplitFlowAfterTransfer(client);
+  }, 25000);
+
 });

--- a/tests/integration/token/TokenUsageExampleTest.ts
+++ b/tests/integration/token/TokenUsageExampleTest.ts
@@ -4,7 +4,7 @@ import { DockerComposeEnvironment, StartedDockerComposeEnvironment, Wait } from 
 
 import { AggregatorClient } from '../../../src/api/AggregatorClient.js';
 import { StateTransitionClient } from '../../../src/StateTransitionClient.js';
-import { testTransferFlow, testSplitFlow } from '../../token/CommonTestFlow.js';
+import { testTransferFlow, testSplitFlow, testSplitFlowAfterTransfer } from '../../token/CommonTestFlow.js';
 
 const aggregatorPort = 3000; // the port defined in docker-compose.yml
 const containerName = 'aggregator-test'; // the container name defined in docker-compose.yml
@@ -43,5 +43,9 @@ describe('Transition', function () {
 
   it('should split tokens', async () => {
     await testSplitFlow(client);
+  }, 30000);
+
+  it('should split tokens after transfer', async () => {
+    await testSplitFlowAfterTransfer(client);
   }, 30000);
 });

--- a/tests/unit/token/TokenUsageExampleTest.ts
+++ b/tests/unit/token/TokenUsageExampleTest.ts
@@ -2,7 +2,7 @@ import { HashAlgorithm } from '@unicitylabs/commons/lib/hash/HashAlgorithm.js';
 import { SparseMerkleTree } from '@unicitylabs/commons/lib/smt/SparseMerkleTree.js';
 
 import { StateTransitionClient } from '../../../src/StateTransitionClient.js';
-import { testTransferFlow, testSplitFlow } from '../../token/CommonTestFlow.js';
+import { testTransferFlow, testSplitFlow, testSplitFlowAfterTransfer } from '../../token/CommonTestFlow.js';
 import { TestAggregatorClient } from '../TestAggregatorClient.js';
 
 describe('Transition', function () {
@@ -14,5 +14,9 @@ describe('Transition', function () {
 
   it('should split tokens', async () => {
     await testSplitFlow(client);
+  }, 15000);
+
+  it('should split tokens after transfer', async () => {
+    await testSplitFlowAfterTransfer(client);
   }, 15000);
 });


### PR DESCRIPTION
Adding additional test in order to test if it is possible to perform actions on top of splited token like: further send, burn and split.